### PR TITLE
Magnetic Field Test

### DIFF
--- a/my_local_models/CmakeLists.txt
+++ b/my_local_models/CmakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+find_package(gazebo REQUIRED)
+
+add_library(MagneticField SHARED MagneticField.ccp)
+
+target_link_libraries(MagneticField ${GAZEBO_LIBRARIES})

--- a/my_local_models/MagneticField.cpp
+++ b/my_local_models/MagneticField.cpp
@@ -35,5 +35,6 @@ namespace gazebo
         event::ConnectionPtr updateConnection; // Pointer to the update event connection
         ignition::math::Vector3d magneticField; // Magnetic field vector
     };
+    
     GZ_REGISTER_MODEL_PLUGIN(MagneticFieldPlugin)
 }

--- a/my_local_models/MagneticField.cpp
+++ b/my_local_models/MagneticField.cpp
@@ -1,1 +1,36 @@
 #include <gazebo/gazebo.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/common/common.hh>
+
+//based on examples from https://github.com/srmainwaring
+
+
+namespace gazebo
+{
+  class MagneticFieldPlugin : public ModelPlugin
+  {
+  public:
+    void Load(physics::ModelPtr _model, sdf::ElementPtr /*_sdf*/)
+    {
+      ignition::math::Vector3d magneticField(0, 0, 0.00005); //TODO changeme later
+      this->model = _model;
+      this->updateConnection = event::Events::ConnectWorldUpdateBegin(
+          std::bind(&MagneticFieldPlugin::OnUpdate, this));
+    }
+
+    void OnUpdate()
+    {
+      // calc and apply magnetic force
+      ignition::math::Vector3d force = magneticField * this->model->WorldPose().Pos(); 
+      this->model->GetLink()->AddForce(force);
+      // should add to model
+    }
+
+  private:
+    physics::ModelPtr model;
+    event::ConnectionPtr updateConnection;
+    ignition::math::Vector3d magneticField; //gz behavior
+  };
+
+  GZ_REGISTER_MODEL_PLUGIN(MagneticFieldPlugin)
+}

--- a/my_local_models/MagneticField.cpp
+++ b/my_local_models/MagneticField.cpp
@@ -4,33 +4,36 @@
 
 //based on examples from https://github.com/srmainwaring
 
-
 namespace gazebo
 {
-  class MagneticFieldPlugin : public ModelPlugin
-  {
-  public:
-    void Load(physics::ModelPtr _model, sdf::ElementPtr /*_sdf*/)
+    // Derived from the ModelPlugin class
+    class MagneticField : public ModelPlugin
     {
-      ignition::math::Vector3d magneticField(0, 0, 0.00005); //TODO changeme later
-      this->model = _model;
-      this->updateConnection = event::Events::ConnectWorldUpdateBegin(
-          std::bind(&MagneticFieldPlugin::OnUpdate, this));
-    }
+    public:
+        // load function - for when the plugin is inserted into the simulation
+        void Load(physics::ModelPtr _model, sdf::ElementPtr /*_sdf*/)
+        {
+            // set a magnetic field vector
+            ignition::math::Vector3d magneticField(0, 0, 0.00005); //TODO changeme later
+            this->model = _model;
+            // connect to the world update event
+            this->updateConnection = event::Events::ConnectWorldUpdateBegin(
+                    std::bind(&MagneticFieldPlugin::OnUpdate, this));
+        }
 
-    void OnUpdate()
-    {
-      // calc and apply magnetic force
-      ignition::math::Vector3d force = magneticField * this->model->WorldPose().Pos(); 
-      this->model->GetLink()->AddForce(force);
-      // should add to model
-    }
+        // called on every timestep (?)
+        void OnUpdate()
+        {
+            // calc the magnetic force based on the model's position
+            ignition::math::Vector3d force = magneticField * this->model->WorldPose().Pos(); 
+            // apply the force to the model
+            this->model->GetLink()->AddForce(force);
+        }
 
-  private:
-    physics::ModelPtr model;
-    event::ConnectionPtr updateConnection;
-    ignition::math::Vector3d magneticField; //gz behavior
-  };
-
-  GZ_REGISTER_MODEL_PLUGIN(MagneticFieldPlugin)
+    private:
+        physics::ModelPtr model; // Pointer to the model
+        event::ConnectionPtr updateConnection; // Pointer to the update event connection
+        ignition::math::Vector3d magneticField; // Magnetic field vector
+    };
+    GZ_REGISTER_MODEL_PLUGIN(MagneticFieldPlugin)
 }


### PR DESCRIPTION
This pull request introduces a new `MagneticField` plugin for the Gazebo simulation environment. The main changes include setting up the CMake configuration and implementing the plugin to apply a magnetic force to a model.

### CMake Configuration:
* [`my_local_models/CmakeLists.txt`](diffhunk://#diff-f9b63007f43a4e86eea3bdec8a3ca1dfc461c8449301d1f5bebdc5ab22583349R1-R7): Added CMake configuration to find the Gazebo package and link it with the `MagneticField` library.

### Plugin Implementation:
* [`my_local_models/MagneticField.cpp`](diffhunk://#diff-1d261e98a8fa6e7e7a48d4ac979893fcac5582d54030b18477c5ad19f7db01d0R2-R40): Implemented the `MagneticField` plugin, which applies a magnetic force to a model based on its position in the simulation.